### PR TITLE
createContractProto: use empty slice if order is nil

### DIFF
--- a/client_utils.go
+++ b/client_utils.go
@@ -781,8 +781,12 @@ func createContractProto(contract *Contract, order *Order) *protobuf.Contract {
 	if !stringIsEmpty(contract.ComboLegsDescrip) {
 		contractProto.ComboLegsDescrip = &contract.ComboLegsDescrip
 	}
-	if len(contract.ComboLegs) > 0 && order != nil {
-		contractProto.ComboLegs = createComboLegsProto(contract.ComboLegs, order.OrderComboLegs)
+	if len(contract.ComboLegs) > 0 {
+		var legs []OrderComboLeg
+		if order != nil {
+			legs = order.OrderComboLegs
+		}
+		contractProto.ComboLegs = createComboLegsProto(contract.ComboLegs, legs)
 	}
 
 	return contractProto


### PR DESCRIPTION
I believe we still want to call `createComboLegsProto` to build the protos, even if order is nil. as we are only using the prices of the legs from the order, and if not present we use `UNSET_FLOAT`