### PR TITLE
Fix inverted isValidInt64Value check for HedgeMaxSize

### DIFF
--- a/client_utils.go
+++ b/client_utils.go
@@ -304,7 +304,7 @@ func createOrderProto(order *Order) (*protobuf.Order, error) {
 	if !stringIsEmpty(order.HedgeParam) {
 		orderProto.HedgeParam = &order.HedgeParam
 	}
-	if !isValidInt64Value(order.HedgeMaxSize) {
+	if isValidInt64Value(order.HedgeMaxSize) {
 		hedgeMaxSize := int32(order.HedgeMaxSize)
 		orderProto.HedgeMaxSize = &hedgeMaxSize
 	}


### PR DESCRIPTION
## Summary
- The condition `!isValidInt64Value(order.HedgeMaxSize)` in `createOrderProto` was inverted, causing `HedgeMaxSize` to be sent when the value is UNSET_INT (invalid), resulting in code=503 rejection on every protobuf-encoded order
- Removes the negation so the field is only populated when explicitly set

## Test plan
- [ ] Place a protobuf-encoded order without setting HedgeMaxSize — verify no 503 rejection
- [ ] Place a protobuf-encoded order with HedgeMaxSize explicitly set — verify the value is sent correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)