### PR TITLE
Guard nil connection operations

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -34,6 +34,10 @@ type Connection struct {
 }
 
 func (c *Connection) Write(bs []byte) (int, error) {
+	if c == nil {
+		return 0, fmt.Errorf("connection is nil")
+	}
+
 	// Fast path: try write with current connection
 	conn := c.getConn()
 	if conn != nil {
@@ -74,6 +78,10 @@ func (c *Connection) Write(bs []byte) (int, error) {
 }
 
 func (c *Connection) Read(bs []byte) (int, error) {
+	if c == nil {
+		return 0, fmt.Errorf("connection is nil")
+	}
+
 	conn := c.getConn()
 	if conn == nil {
 		return 0, fmt.Errorf("connection not available")
@@ -195,6 +203,10 @@ func (c *Connection) reconnect() error {
 }
 
 func (c *Connection) disconnect() error {
+	if c == nil {
+		return nil
+	}
+
 	// Load statistics atomically for logging
 	msgSent := atomic.LoadInt64(&c.numMsgSent)
 	bytesSent := atomic.LoadInt64(&c.numBytesSent)

--- a/connection_race_test.go
+++ b/connection_race_test.go
@@ -79,6 +79,39 @@ func (s *DummyServer) Address() (string, int) {
 	return s.addr, s.port
 }
 
+func TestConnectionNilReceiverDoesNotPanic(t *testing.T) {
+	var conn *Connection
+
+	assertNoPanic(t, "write", func() {
+		if _, err := conn.Write([]byte("test")); err == nil {
+			t.Fatal("expected write on nil connection to return an error")
+		}
+	})
+
+	assertNoPanic(t, "read", func() {
+		buf := make([]byte, 4)
+		if _, err := conn.Read(buf); err == nil {
+			t.Fatal("expected read on nil connection to return an error")
+		}
+	})
+
+	assertNoPanic(t, "disconnect", func() {
+		if err := conn.disconnect(); err != nil {
+			t.Fatalf("expected disconnect on nil connection to be a no-op: %v", err)
+		}
+	})
+}
+
+func assertNoPanic(t *testing.T, name string, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("%s panicked: %v", name, r)
+		}
+	}()
+	fn()
+}
+
 // TestConnectionRaceConditions demonstrates race conditions in Connection
 func TestConnectionRaceConditions(t *testing.T) {
 	// Start dummy server


### PR DESCRIPTION
## Summary
- Return errors instead of panicking when Write or Read is called on a nil Connection receiver.
- Make disconnect on a nil Connection a no-op.
- Add regression coverage for nil receiver Write, Read, and disconnect.

## Why
In long-running IB Gateway/TWS API clients, disconnect/reconnect paths can race with shutdown or connection setup failures. Returning an error is safer for callers than a nil-pointer panic, and matches the existing behavior for unavailable TCP connections.

## Testing
- go test ./... -run 'TestConnectionNilReceiverDoesNotPanic|TestConnectionStatisticsRace' -timeout 30s